### PR TITLE
Fixes to Acceleration units and Grams literal

### DIFF
--- a/AccelerationType.h
+++ b/AccelerationType.h
@@ -39,11 +39,11 @@ namespace Units
 
 //https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b8
 UNIT_TEMPLATE(Acceleration, StandardGravity, 9.80665, g0); // acceleration of free fall, standard (gn)
-UNIT_TEMPLATE(Acceleration, MetersPerHourSquared, 12960000.0, meter_per_hour_2); // (1 m) / (1/(3600^2) hr/sec^2)
+UNIT_TEMPLATE(Acceleration, MetersPerHourSquared, (1.0 / 12960000.0), meter_per_hour_2); // (1 m) / (1/(3600^2) hr/sec^2)
 UNIT_TEMPLATE(Acceleration, FeetPerMinuteSquared, (0.3048 / 3600.0), fpm2); // (0.3048 m/ft) / (60^2 min^2/sec)
 UNIT_TEMPLATE(Acceleration, FeetPerSecondSquared, 0.3048, fps2); // (0.3048 m/ft)
 UNIT_TEMPLATE(Acceleration, MilesPerHourSquared, (1609.344 / 12960000.0), mph2); // (1609.344 m/mi) / (3600^2 sec^2/hr)
-UNIT_TEMPLATE(Acceleration, KilometersPerHourSquared, (10.0 / 1296.0), kph2); // (1000 m/km) / (3600^2 sec^2/hr)
+UNIT_TEMPLATE(Acceleration, KilometersPerHourSquared, (1.0 / 12960.0), kph2); // (1000 m/km) / (3600^2 sec^2/hr)
 UNIT_TEMPLATE(Acceleration, InchesPerSecondSquared, 0.0254, inps2);
 UNIT_TEMPLATE(Acceleration, Galileo, 0.01, Galileo);
 UNIT_TEMPLATE(Acceleration, MetersPerSecondSquared, 1.0, mps2);

--- a/MassType.h
+++ b/MassType.h
@@ -49,7 +49,7 @@ UNIT_TEMPLATE(Mass, Megagrams, (double(std::mega::num) / double(std::mega::den))
 UNIT_TEMPLATE(Mass, Kilograms, (double(std::kilo::num) / double(std::kilo::den)), kg);
 UNIT_TEMPLATE(Mass, Hectograms, (double(std::hecto::num) / double(std::hecto::den)), Hg);
 UNIT_TEMPLATE(Mass, Decagrams, (double(std::deca::num) / double(std::deca::den)), Dg);
-UNIT_TEMPLATE(Mass, Grams, 1.0, m);
+UNIT_TEMPLATE(Mass, Grams, 1.0, g);
 UNIT_TEMPLATE(Mass, Decigrams, (double(std::deci::num) / double(std::deci::den)), dg);
 UNIT_TEMPLATE(Mass, Centigrams, (double(std::centi::num) / double(std::centi::den)), cg);
 UNIT_TEMPLATE(Mass, Milligrams, (double(std::milli::num) / double(std::milli::den)), mg);


### PR DESCRIPTION
This commit fixes the MetersPerHourSquared
and KilometersPerHourSquared values in Acceleration.

This also updates the literal for Grams from 'm' to 'g'