### PR TITLE
Remove Pressure namespace in header.

### DIFF
--- a/PressureType.h
+++ b/PressureType.h
@@ -27,8 +27,8 @@ namespace Units
    {
    public:
 
-      Force Pressure::operator*(const Area& area) const;
-      Area Pressure::operator/(const Force& force) const;
+      Force operator*(const Area& area) const;
+      Area operator/(const Force& force) const;
 
       GENERIC_OPERATORS(Pressure);
    };


### PR DESCRIPTION
This was unnecessary and caused a warning when using GCC 12.

Addresses issue #16